### PR TITLE
Added autocomplete functionality using the input accessary view. Ability to customize tag separators.

### DIFF
--- a/Example/SMTagFieldExample.xcodeproj/project.pbxproj
+++ b/Example/SMTagFieldExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2958CCB718331C9E00B445F4 /* SMAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2958CCB618331C9E00B445F4 /* SMAccessoryView.m */; };
 		7831655F17CC959A007FB564 /* ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7831655E17CC959A007FB564 /* ViewController.xib */; };
 		787665671771C9E5006F4888 /* SMTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 787665641771C9E5006F4888 /* SMTag.m */; };
 		787665681771C9E5006F4888 /* SMTagField.m in Sources */ = {isa = PBXBuildFile; fileRef = 787665661771C9E5006F4888 /* SMTagField.m */; };
@@ -23,6 +24,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2958CCB518331C9E00B445F4 /* SMAccessoryView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMAccessoryView.h; sourceTree = "<group>"; };
+		2958CCB618331C9E00B445F4 /* SMAccessoryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SMAccessoryView.m; sourceTree = "<group>"; };
 		781AA856177857AD00D505B5 /* SMTagFieldDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMTagFieldDelegate.h; sourceTree = "<group>"; };
 		7831655E17CC959A007FB564 /* ViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ViewController.xib; sourceTree = "<group>"; };
 		787665631771C9E5006F4888 /* SMTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = SMTag.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -63,6 +66,8 @@
 		787665621771C9D6006F4888 /* SMTagField */ = {
 			isa = PBXGroup;
 			children = (
+				2958CCB518331C9E00B445F4 /* SMAccessoryView.h */,
+				2958CCB618331C9E00B445F4 /* SMAccessoryView.m */,
 				787665631771C9E5006F4888 /* SMTag.h */,
 				787665641771C9E5006F4888 /* SMTag.m */,
 				787665651771C9E5006F4888 /* SMTagField.h */,
@@ -197,6 +202,7 @@
 				78A439A11771C99E00BD1AE5 /* main.m in Sources */,
 				78A439A51771C99E00BD1AE5 /* AppDelegate.m in Sources */,
 				78A439AE1771C99E00BD1AE5 /* ViewController.m in Sources */,
+				2958CCB718331C9E00B445F4 /* SMAccessoryView.m in Sources */,
 				787665671771C9E5006F4888 /* SMTag.m in Sources */,
 				787665681771C9E5006F4888 /* SMTagField.m in Sources */,
 			);

--- a/Example/SMTagFieldExample/ViewController.m
+++ b/Example/SMTagFieldExample/ViewController.m
@@ -22,6 +22,7 @@
     
     log.editable                = NO;
     tagField.tagDelegate        = self;
+    [tagField setupAutoComplete];
     
     tagField.tags               = @[@"Tag1", @"Tag2", @"Tag3"];
 }
@@ -44,6 +45,10 @@
         return NO;
     
     return YES;
+}
+
+-(NSArray *)tagField:(SMTagField *)tagField autoCompleteTagsForTextEntered:(NSString *)text {
+    return @[@"AutoTag1", @"AutoTag2", @"AutoTag3"];
 }
 
 @end

--- a/SMAccessoryView.h
+++ b/SMAccessoryView.h
@@ -2,7 +2,7 @@
 //  SMAccessoryView.h
 //  SMTagFieldExample
 //
-//  Created by Yaakov Shurpin on 11/12/13.
+//  Created by Jack Shurpin on 11/12/13.
 //  Copyright (c) 2013 Shai Mishali. All rights reserved.
 //
 

--- a/SMAccessoryView.h
+++ b/SMAccessoryView.h
@@ -1,0 +1,28 @@
+//
+//  SMAccessoryView.h
+//  SMTagFieldExample
+//
+//  Created by Yaakov Shurpin on 11/12/13.
+//  Copyright (c) 2013 Shai Mishali. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "SMTag.h"
+
+@protocol SMAutoComplete <NSObject>
+
+-(void)autoCompleteTagTapped:(SMTag *)tag;
+
+@end
+
+@interface SMAccessoryView : UIView
+
+/**
+ The tags array, should be returned to SMTagField by its delegate
+ */
+@property (nonatomic, strong) NSArray *tags;
+
+
+@property (weak, nonatomic) id <SMAutoComplete> delegate;
+
+@end

--- a/SMAccessoryView.m
+++ b/SMAccessoryView.m
@@ -1,0 +1,117 @@
+//
+//  SMAccessoryView.m
+//  SMTagFieldExample
+//
+//  Created by Yaakov Shurpin on 11/12/13.
+//  Copyright (c) 2013 Shai Mishali. All rights reserved.
+//
+
+#import "SMAccessoryView.h"
+
+@implementation SMAccessoryView
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Initialization code
+           [self setupUI];
+    }
+    return self;
+}
+
+
+@synthesize tags;
+
+
+-(void)setTags:(NSArray *)aTags{
+    tags = aTags;
+    [self layoutTags];
+}
+
+#pragma mark - View Flow
+
+-(void)awakeFromNib{
+    [self setupUI];
+    [super awakeFromNib];
+}
+
+
+//mostly a copy of code in SMTagField
+#pragma mark - Private Methods
+-(void)setupUI{
+    self.backgroundColor        = [UIColor whiteColor];
+    self.opaque                 = NO;
+
+    
+    tags                        = @[];
+}
+
+-(void)layoutTags{
+    [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    
+    CGRect tagsFrame        = self.frame;
+    tagsFrame.size          = CGSizeMake(0, 30);
+    self.frame          = tagsFrame;
+    
+    
+    for(NSString *txtTag in tags){
+        SMTag *tag              = [[SMTag alloc] initWithTag: txtTag];
+        
+        [tag addTarget:self action:@selector(tagTapped:) forControlEvents:UIControlEventTouchUpInside];
+        
+        CGRect tagFrame         = tag.frame;
+        tagFrame.origin.x       = self.frame.size.width + 5;
+        tagFrame.origin.y       = (self.frame.size.height - tag.frame.size.height) / 2;
+        tag.frame               = tagFrame;
+        
+        tagsFrame               = self.frame;
+        tagsFrame.size.width   += (tag.frame.size.width + 5);
+        self.frame          = tagsFrame;
+        
+        [self addSubview: tag];
+    }
+    
+    // If there's not enough room, free up first tags and reposition next ones
+    CGFloat missingWidth= (self.frame.size.width - self.frame.size.width + 40);
+    
+    if(missingWidth > 0){
+        // Remove old tags
+        for(SMTag *tag in self.subviews){
+            if(missingWidth < 0)
+                break;
+            
+            missingWidth -= tag.frame.size.width;
+            
+            [tag removeFromSuperview];
+        }
+        
+        tagsFrame                   = self.frame;
+        
+        tagsFrame.size.width        = 0;
+        
+        self.frame              = tagsFrame;
+        
+        // Reposition
+        for(SMTag *tag in self.subviews){
+            CGRect tagFrame         = tag.frame;
+            tagFrame.origin.x       = self.frame.size.width + 5;
+            tagFrame.origin.y       = (self.frame.size.height - tag.frame.size.height) / 2;
+            tag.frame               = tagFrame;
+            
+            tagsFrame               = self.frame;
+            tagsFrame.size.width   += (tag.frame.size.width + 5);
+            self.frame          = tagsFrame;
+            
+            [self addSubview: tag];
+        }
+    }
+}
+
+-(void)tagTapped:(SMTag *)tag {
+    if (self.delegate && [self.delegate respondsToSelector:@selector(autoCompleteTagTapped:)]) {
+        [self.delegate autoCompleteTagTapped:tag];
+    }
+}
+         
+@end

--- a/SMAccessoryView.m
+++ b/SMAccessoryView.m
@@ -2,7 +2,7 @@
 //  SMAccessoryView.m
 //  SMTagFieldExample
 //
-//  Created by Yaakov Shurpin on 11/12/13.
+//  Created by Jack Shurpin on 11/12/13.
 //  Copyright (c) 2013 Shai Mishali. All rights reserved.
 //
 

--- a/SMTagField.h
+++ b/SMTagField.h
@@ -8,16 +8,27 @@
 #import <UIKit/UIKit.h>
 #import "SMTag.h"
 #import "SMTagFieldDelegate.h"
-
+#import "SMAccessoryView.h"
 /**
  SMTagField is an implementation of UITextField that allows for easy input/display of tags
  */
-@interface SMTagField : UITextField
+@interface SMTagField : UITextField <SMAutoComplete>
 
 /**
  The tags array, contains all of the tags. Can be set manually
  */
 @property (nonatomic, strong) NSArray *tags;
+
+/**
+  An array of seprators to determine what seperates a tag, defaults to " " and ",".
+ */
+@property (nonatomic, strong) NSArray *tagSeparators;
+
+
+/** 
+    Method to setup autocomplete field in input accessary view, must also implement delegate method
+ */
+-(void)setupAutoComplete;
 
 /**
  The SMTagField Delegate. See documentation above

--- a/SMTagFieldDelegate.h
+++ b/SMTagFieldDelegate.h
@@ -42,4 +42,13 @@
  */
 -(BOOL) tagField: (SMTagField *) tagField shouldAddTag: (NSString *) tag;
 
+
+/**
+    Provides a list of autocomplete tags to SMTagField.
+ @param tagField The tagField
+ @param text The text just entered
+ @return array of tags
+ */
+-(NSArray *)tagField: (SMTagField *)tagField autoCompleteTagsForTextEntered:(NSString *)text;
+
 @end


### PR DESCRIPTION
Whenever the text changes if the delegate implements the appropriate method call it and get back an array of tags which are then displayed in the input accessary view. When these tags are tapped they are added to the tag collection (replacing the current text).

Also added a tag senators property which the user can set if they want to use different characters to separate tags.
