### PR TITLE
Fixing Removing tag for iOS 8.

### DIFF
--- a/SMTagField.m
+++ b/SMTagField.m
@@ -241,4 +241,22 @@
         [tagDelegate tagField: self tagsChanged: tags];
 }
 
+-(BOOL)keyboardInputShouldDelete:(UITextField *)textField {
+    BOOL shouldDelete = YES;
+    
+    if ([UITextField instancesRespondToSelector:_cmd]) {
+        BOOL (*keyboardInputShouldDelete)(id, SEL, UITextField *) = (BOOL (*)(id, SEL, UITextField *))[UITextField instanceMethodForSelector:_cmd];
+        
+        if (keyboardInputShouldDelete) {
+            shouldDelete = keyboardInputShouldDelete(self, _cmd, textField);
+        }
+    }
+    
+    if (![textField.text length] && [[[UIDevice currentDevice] systemVersion] intValue] >= 8) {
+        [self deleteBackward];
+    }
+    
+    return shouldDelete;
+}
+
 @end


### PR DESCRIPTION
Fixing removing tag in iOS 8 by adding a new delegate method.
